### PR TITLE
Fix screenshot functionality to handle all path formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ After configuring, restart your AI assistant to load the new server configuratio
   - **Linux**: `xclip` (install via `apt-get install xclip` or equivalent)
 - Node.js 16.x or higher
 
-## �� Features
+## 🚀 Features
 
 - Connect to and manage multiple Android devices
 - Execute shell commands on Android devices

--- a/README.md
+++ b/README.md
@@ -1,147 +1,69 @@
 # Android ADB MCP Server
 
-A Model Context Protocol (MCP) server that enables AI assistants to interact with Android devices through the Android Debug Bridge (ADB). This server bridges the gap between AI capabilities and Android device management, allowing for seamless automation of Android development and testing operations.
+This MCP server provides tools for interacting with Android devices through the Android Debug Bridge (ADB). It enables AI assistants to perform common Android development and testing operations.
 
-## ⚙️ Quick Setup
+## Features
 
-Add the server to your MCP configuration file:
-
-```json
-{
-  "mcpServers": {
-    "android-adb": {
-      "command": "npx",
-      "args": ["-y", "@landicefu/android-adb-mcp-server"],
-      "env": {},
-      "disabled": false,
-      "alwaysAllow": []
-    }
-  }
-}
-```
-
-### Configuration Locations
-
-- **Claude Desktop**: `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
-- **Cline/Roo Code**: `~/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/cline_mcp_settings.json` (macOS)
-- For Windows/Linux, check the equivalent application support directories
-
-After configuring, restart your AI assistant to load the new server configuration.
-
-## 📋 Prerequisites
-
-- **ADB (Android Debug Bridge)** must be installed and available in your system PATH
-  - [Install ADB on Windows, macOS, or Linux](https://developer.android.com/tools/adb)
-  - Verify installation by running `adb version` in your terminal
-- For clipboard functionality:
-  - **macOS**: `osascript` (built-in)
-  - **Windows**: PowerShell (built-in)
-  - **Linux**: `xclip` (install via `apt-get install xclip` or equivalent)
-- Node.js 16.x or higher
-
-## 🚀 Features
-
-- Connect to and manage multiple Android devices
+- List connected Android devices
 - Execute shell commands on Android devices
 - Install and uninstall applications
-- Push and pull files between local system and Android devices
-- Launch applications on Android devices
-- Take screenshots and save them locally or copy to clipboard
-- Smart device selection when multiple devices are connected
+- List installed packages
+- Pull and push files between the device and local system
+- Launch applications
+- Take screenshots and save them or copy to clipboard
 
-## 🛠️ Available Tools
-
-| Tool | Description | Required Parameters | Optional Parameters |
-|------|-------------|---------------------|---------------------|
-| `adb_devices` | List connected devices | None | None |
-| `adb_shell` | Execute shell commands | `command` | `device_id` |
-| `adb_install` | Install APK files | `path` | `device_id` |
-| `adb_uninstall` | Uninstall applications | `package_name` | `device_id` |
-| `adb_list_packages` | List installed packages | None | `device_id`, `filter` |
-| `adb_pull` | Pull files from device | `remote_path`, `local_path` | `device_id` |
-| `adb_push` | Push files to device | `local_path`, `remote_path` | `device_id` |
-| `launch_app` | Launch an application | `package_name` | `device_id` |
-| `take_screenshot_and_save` | Take and save screenshot | `output_path` | `device_id`, `format` |
-| `take_screenshot_and_copy_to_clipboard` | Take screenshot to clipboard | None | `device_id`, `format` |
-
-### Device Management
-
-The server intelligently handles device selection:
-- If only one device is connected, it will be used automatically
-- If multiple devices are connected, you must specify a `device_id` parameter
-- If no devices are connected, an error will be returned
-
-## 🔍 Troubleshooting
-
-### Common Issues
-
-1. **"ADB is not available" error**
-   - Ensure ADB is installed and in your system PATH
-   - Verify by running `adb version` in your terminal
-
-2. **"No Android devices connected" error**
-   - Check if your device is properly connected with `adb devices`
-   - Ensure USB debugging is enabled on your device
-   - Try restarting ADB with `adb kill-server` followed by `adb start-server`
-
-3. **"Multiple devices connected" error**
-   - Specify the `device_id` parameter in your tool call
-   - Get the list of available devices with the `adb_devices` tool
-
-4. **Screenshot to clipboard not working**
-   - Ensure the required platform-specific tools are installed
-
-## 🔧 Alternative Installation Methods
-
-### Option 1: Install from npm
+## Installation
 
 ```bash
-# Install globally
 npm install -g @landicefu/android-adb-mcp-server
-
-# Or install locally in your project
-npm install @landicefu/android-adb-mcp-server
 ```
 
-### Option 2: Manual Installation from Source
+## Requirements
 
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/landicefu/android-adb-mcp-server.git
-   cd android-adb-mcp-server
-   ```
+- Node.js 14 or later
+- Android SDK Platform Tools (adb) installed and in your PATH
 
-2. Install dependencies and build:
-   ```bash
-   npm install
-   npm run build
-   ```
+## Usage
 
-3. Configure with direct path:
-   ```json
-   {
-     "mcpServers": {
-       "android-adb": {
-         "command": "node",
-         "args": ["/path/to/android-adb-mcp-server/build/index.js"],
-         "env": {},
-         "disabled": false,
-         "alwaysAllow": []
-       }
-     }
-   }
-   ```
+### Taking Screenshots
 
-## 📄 License
+The server provides two tools for taking screenshots:
 
-This project is licensed under the ISC License - see the LICENSE file for details.
+1. `take_screenshot_and_save`: Takes a screenshot and saves it to the local system
+2. `take_screenshot_and_copy_to_clipboard`: Takes a screenshot and copies it to the clipboard
 
-## 🤝 Contributing
+#### Path Resolution
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+When specifying the `output_path` for saving screenshots, the path is resolved as follows:
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+- Absolute paths are used as-is
+- Paths starting with `~` are expanded to the user's home directory
+- Relative paths are resolved relative to the user's home directory
+
+This ensures that screenshots are saved to a location where the MCP server has write permissions.
+
+#### Example
+
+```javascript
+// Save screenshot to the user's home directory
+await use_mcp_tool({
+  server_name: "android-adb",
+  tool_name: "take_screenshot_and_save",
+  arguments: {
+    output_path: "~/screenshot.png"
+  }
+});
+
+// Save screenshot to an absolute path
+await use_mcp_tool({
+  server_name: "android-adb",
+  tool_name: "take_screenshot_and_save",
+  arguments: {
+    output_path: "/Users/username/Documents/screenshot.png"
+  }
+});
+```
+
+## License
+
+ISC

--- a/README.md
+++ b/README.md
@@ -1,69 +1,156 @@
 # Android ADB MCP Server
 
-This MCP server provides tools for interacting with Android devices through the Android Debug Bridge (ADB). It enables AI assistants to perform common Android development and testing operations.
+A Model Context Protocol (MCP) server that enables AI assistants to interact with Android devices through the Android Debug Bridge (ADB). This server bridges the gap between AI capabilities and Android device management, allowing for seamless automation of Android development and testing operations.
 
-## Features
+## ⚙️ Quick Setup
 
-- List connected Android devices
-- Execute shell commands on Android devices
-- Install and uninstall applications
-- List installed packages
-- Pull and push files between the device and local system
-- Launch applications
-- Take screenshots and save them or copy to clipboard
+Add the server to your MCP configuration file:
 
-## Installation
-
-```bash
-npm install -g @landicefu/android-adb-mcp-server
+```json
+{
+  "mcpServers": {
+    "android-adb": {
+      "command": "npx",
+      "args": ["-y", "@landicefu/android-adb-mcp-server"],
+      "env": {},
+      "disabled": false,
+      "alwaysAllow": []
+    }
+  }
+}
 ```
 
-## Requirements
+### Configuration Locations
 
-- Node.js 14 or later
-- Android SDK Platform Tools (adb) installed and in your PATH
+- **Claude Desktop**: `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
+- **Cline/Roo Code**: `~/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/cline_mcp_settings.json` (macOS)
+- For Windows/Linux, check the equivalent application support directories
 
-## Usage
+After configuring, restart your AI assistant to load the new server configuration.
 
-### Taking Screenshots
+## 📋 Prerequisites
 
-The server provides two tools for taking screenshots:
+- **ADB (Android Debug Bridge)** must be installed and available in your system PATH
+  - [Install ADB on Windows, macOS, or Linux](https://developer.android.com/tools/adb)
+  - Verify installation by running `adb version` in your terminal
+- For clipboard functionality:
+  - **macOS**: `osascript` (built-in)
+  - **Windows**: PowerShell (built-in)
+  - **Linux**: `xclip` (install via `apt-get install xclip` or equivalent)
+- Node.js 16.x or higher
 
-1. `take_screenshot_and_save`: Takes a screenshot and saves it to the local system
-2. `take_screenshot_and_copy_to_clipboard`: Takes a screenshot and copies it to the clipboard
+## �� Features
 
-#### Path Resolution
+- Connect to and manage multiple Android devices
+- Execute shell commands on Android devices
+- Install and uninstall applications
+- Push and pull files between local system and Android devices
+- Launch applications on Android devices
+- Take screenshots and save them locally or copy to clipboard
+- Smart device selection when multiple devices are connected
+
+## 🛠️ Available Tools
+
+| Tool | Description | Required Parameters | Optional Parameters |
+|------|-------------|---------------------|---------------------|
+| `adb_devices` | List connected devices | None | None |
+| `adb_shell` | Execute shell commands | `command` | `device_id` |
+| `adb_install` | Install APK files | `path` | `device_id` |
+| `adb_uninstall` | Uninstall applications | `package_name` | `device_id` |
+| `adb_list_packages` | List installed packages | None | `device_id`, `filter` |
+| `adb_pull` | Pull files from device | `remote_path`, `local_path` | `device_id` |
+| `adb_push` | Push files to device | `local_path`, `remote_path` | `device_id` |
+| `launch_app` | Launch an application | `package_name` | `device_id` |
+| `take_screenshot_and_save` | Take and save screenshot | `output_path` | `device_id`, `format` |
+| `take_screenshot_and_copy_to_clipboard` | Take screenshot to clipboard | None | `device_id`, `format` |
+
+### Device Management
+
+The server intelligently handles device selection:
+- If only one device is connected, it will be used automatically
+- If multiple devices are connected, you must specify a `device_id` parameter
+- If no devices are connected, an error will be returned
+
+### Screenshot Path Resolution
 
 When specifying the `output_path` for saving screenshots, the path is resolved as follows:
-
 - Absolute paths are used as-is
 - Paths starting with `~` are expanded to the user's home directory
 - Relative paths are resolved relative to the user's home directory
 
 This ensures that screenshots are saved to a location where the MCP server has write permissions.
 
-#### Example
+## 🔍 Troubleshooting
 
-```javascript
-// Save screenshot to the user's home directory
-await use_mcp_tool({
-  server_name: "android-adb",
-  tool_name: "take_screenshot_and_save",
-  arguments: {
-    output_path: "~/screenshot.png"
-  }
-});
+### Common Issues
 
-// Save screenshot to an absolute path
-await use_mcp_tool({
-  server_name: "android-adb",
-  tool_name: "take_screenshot_and_save",
-  arguments: {
-    output_path: "/Users/username/Documents/screenshot.png"
-  }
-});
+1. **"ADB is not available" error**
+   - Ensure ADB is installed and in your system PATH
+   - Verify by running `adb version` in your terminal
+
+2. **"No Android devices connected" error**
+   - Check if your device is properly connected with `adb devices`
+   - Ensure USB debugging is enabled on your device
+   - Try restarting ADB with `adb kill-server` followed by `adb start-server`
+
+3. **"Multiple devices connected" error**
+   - Specify the `device_id` parameter in your tool call
+   - Get the list of available devices with the `adb_devices` tool
+
+4. **Screenshot to clipboard not working**
+   - Ensure the required platform-specific tools are installed
+
+## 🔧 Alternative Installation Methods
+
+### Option 1: Install from npm
+
+```bash
+# Install globally
+npm install -g @landicefu/android-adb-mcp-server
+
+# Or install locally in your project
+npm install @landicefu/android-adb-mcp-server
 ```
 
-## License
+### Option 2: Manual Installation from Source
 
-ISC
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/landicefu/android-adb-mcp-server.git
+   cd android-adb-mcp-server
+   ```
+
+2. Install dependencies and build:
+   ```bash
+   npm install
+   npm run build
+   ```
+
+3. Configure with direct path:
+   ```json
+   {
+     "mcpServers": {
+       "android-adb": {
+         "command": "node",
+         "args": ["/path/to/android-adb-mcp-server/build/index.js"],
+         "env": {},
+         "disabled": false,
+         "alwaysAllow": []
+       }
+     }
+   }
+   ```
+
+## 📄 License
+
+This project is licensed under the ISC License - see the LICENSE file for details.
+
+## 🤝 Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add some amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request


### PR DESCRIPTION
## Root Cause

The screenshot functionality was failing with a "Read-only file system" error because:

1. The original implementation used a multi-step process that was prone to failure:
   - Take screenshot on device using `adb shell screencap`
   - Pull the screenshot to a local temp file
   - Convert and save to the desired location
   
2. When using relative paths, the MCP server was trying to save files relative to the current working directory, which might not have write permissions.

3. There was no proper path resolution for tilde (~) paths or validation of directory writability.

## Solution

1. **Direct ADB Command**: Rewrote the screenshot functionality to use a single, direct ADB command that works reliably:
   ```
   adb exec-out screencap -p > /path/to/screenshot.png
   ```
   This approach streams the screenshot data directly to the output file without creating temporary files on the device.

2. **Path Resolution**: Added proper handling for all path formats:
   - Absolute paths are used as-is
   - Paths starting with `~` are expanded to the user's home directory
   - Relative paths are resolved relative to the user's home directory

3. **Directory Writability Check**: Added checks to ensure the output directory exists and is writable before attempting to save the screenshot.

4. **Better Error Messages**: Improved error messages to provide more helpful guidance when issues occur.

5. **Documentation**: Added a "Screenshot Path Resolution" section to the README to document the path handling behavior.

## Testing

Tested on macOS with:
- Absolute paths: /Users/yuji/device_screenshot.png
- Relative paths: device_screenshot.png
- Tilde paths: ~/device_screenshot.png

All formats work correctly and screenshots are saved to the expected locations.
