### PR TITLE
Fix: Remove circular dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/landicefu/android-adb-mcp-server#readme",
   "dependencies": {
-    "@landicefu/android-adb-mcp-server": "^1.0.0",
+    
     "@modelcontextprotocol/sdk": "^1.6.1",
     "sharp": "^0.33.5"
   },


### PR DESCRIPTION
This PR fixes a circular dependency issue in package.json where the package was depending on itself. This was causing installation problems when using npx to run the MCP server.